### PR TITLE
Fix conversion operators

### DIFF
--- a/src/Semver/SemVersion.cs
+++ b/src/Semver/SemVersion.cs
@@ -459,13 +459,33 @@ namespace Semver
 #endif
 
         /// <summary>
-        /// Implicit conversion from string to SemVersion.
+        /// Explicit conversion from string to SemVersion
         /// </summary>
-        /// <param name="version">The semantic version.</param>
-        /// <returns>The SemVersion object.</returns>
-        public static implicit operator SemVersion(string version)
+        /// <param name="version">A string containing a semantic version</param>
+        /// <returns>
+        /// A <see cref="SemVersion"/> object matching <paramref name="version"/>
+        /// - OR -
+        /// <c>null</c> if <paramref name="version"/> was <c>null</c>
+        /// </returns>
+        public static explicit operator SemVersion(string version)
         {
+            if (version == null) return null;
             return SemVersion.Parse(version);
+        }
+
+        /// <summary>
+        /// Implicit conversion from SemVersion to string
+        /// </summary>
+        /// <param name="version">A SemVersion</param>
+        /// <returns>
+        /// String representation of <paramref name="version"/>
+        /// - OR -
+        /// <c>null</c> if <paramref name="version"/> was <c>null</c>
+        /// </returns>
+        public static implicit operator string(SemVersion version)
+        {
+            if (version == null) return null;
+            return version.ToString();
         }
 
         /// <summary>

--- a/test/Semver.Test/SemVersionTest.cs
+++ b/test/Semver.Test/SemVersionTest.cs
@@ -12,21 +12,21 @@ namespace Semver.Test
         [Fact]
         public void CompareTestWithStrings1()
         {
-            Assert.True(SemVersion.Equals("1.0.0", "1"));
+            Assert.True(SemVersion.Equals((SemVersion)"1.0.0", (SemVersion)"1"));
         }
 
         [Fact]
         public void CompareTestWithStrings2()
         {
             var v = new SemVersion(1, 0, 0);
-            Assert.True(v < "1.1");
+            Assert.True(v < (SemVersion)"1.1");
         }
 
         [Fact]
         public void CompareTestWithStrings3()
         {
             var v = new SemVersion(1, 2);
-            Assert.True(v > "1.0.0");
+            Assert.True(v > (SemVersion)"1.0.0");
         }
 
         [Fact]
@@ -509,10 +509,35 @@ namespace Semver.Test
         }
 
         [Fact]
-        public void TestStringConversion()
+        public void Operator_SemVersion_Converts_Correctly()
         {
-            SemVersion v = "1.0.0";
-            Assert.Equal(1, v.Major);
+            var v1 = (SemVersion)"1.0.0";
+            var v2 = new SemVersion(1, 0, 0);
+            Assert.Equal(v1, v2);
+        }
+
+        [Fact]
+        public void Operator_SemVersion_Propagates_Null()
+        {
+            string s = null;
+            SemVersion v = (SemVersion)s;
+            Assert.Equal(null, v);
+        }
+
+        [Fact]
+        public void Operator_String_Converts_Correctly()
+        {
+            SemVersion v = new SemVersion(1, 0, 0);
+            string s = v;
+            Assert.Equal("1.0.0", s);
+        }
+
+        [Fact]
+        public void Operator_String_Propagates_Null()
+        {
+            SemVersion v = null;
+            string s = v;
+            Assert.Equal(null, s);
         }
 
         [Fact]


### PR DESCRIPTION
- Make operator SemVer explicit as it is "narrowing" and can fail if the string
  is not in the correct format

- Teach operator SemVer to propagate nulls

- Add operator string, implicit as it is "widening" and cannot fail

- Tests