### PR TITLE
When parsing fails, add invalid version string to exception message

### DIFF
--- a/Semver.Test/SemVersionParsingTests.cs
+++ b/Semver.Test/SemVersionParsingTests.cs
@@ -311,7 +311,7 @@ namespace Semver.Test
         public void ParseLooseInvalidThrowsArgumentExceptionTest(string versionString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SemVersion.Parse(versionString));
-            Assert.Equal("Invalid version.\r\nParameter name: version", ex.Message);
+            Assert.Equal($"Invalid version '{versionString}'.{Environment.NewLine}Parameter name: version", ex.Message);
         }
 
         [Theory]
@@ -327,7 +327,7 @@ namespace Semver.Test
         {
             var ex = Assert.Throws<ArgumentNullException>(() => SemVersion.Parse(null));
             // TODO that is a strange error message, should be version
-            Assert.Equal("Value cannot be null.\r\nParameter name: input", ex.Message);
+            Assert.Equal($"Value cannot be null.{Environment.NewLine}Parameter name: input", ex.Message);
         }
 
         [Fact]
@@ -373,7 +373,7 @@ namespace Semver.Test
         public void ParseStrictInvalidThrowsArgumentExceptionTest(string versionString)
         {
             var ex = Assert.Throws<ArgumentException>(() => SemVersion.Parse(versionString, true));
-            Assert.Equal("Invalid version.\r\nParameter name: version", ex.Message);
+            Assert.Equal($"Invalid version '{versionString}'.{Environment.NewLine}Parameter name: version", ex.Message);
         }
 
         [Theory]
@@ -407,7 +407,7 @@ namespace Semver.Test
         {
             var ex = Assert.Throws<ArgumentNullException>(() => SemVersion.Parse(null, true));
             // TODO that is a strange error message, should be version
-            Assert.Equal("Value cannot be null.\r\nParameter name: input", ex.Message);
+            Assert.Equal($"Value cannot be null.{Environment.NewLine}Parameter name: input", ex.Message);
         }
 
         [Theory]
@@ -522,7 +522,7 @@ namespace Semver.Test
             {
                 SemVersion _ = versionString;
             });
-            Assert.Equal("Invalid version.\r\nParameter name: version", ex.Message);
+            Assert.Equal($"Invalid version '{versionString}'.{Environment.NewLine}Parameter name: version", ex.Message);
         }
 
         [Theory]
@@ -545,7 +545,7 @@ namespace Semver.Test
                 SemVersion _ = default(string);
             });
             // TODO that is a strange error message, should be version
-            Assert.Equal("Value cannot be null.\r\nParameter name: input", ex.Message);
+            Assert.Equal($"Value cannot be null.{Environment.NewLine}Parameter name: input", ex.Message);
         }
 
         /// <summary>

--- a/Semver/SemVersion.cs
+++ b/Semver/SemVersion.cs
@@ -111,7 +111,7 @@ namespace Semver
         {
             var match = ParseEx.Match(version);
             if (!match.Success)
-                throw new ArgumentException("Invalid version.", nameof(version));
+                throw new ArgumentException($"Invalid version '{version}'.", nameof(version));
 
             var major = int.Parse(match.Groups["major"].Value, CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
- Add version string to `ArgumentException`
- Update tests to support new exception message
- Also updated tests to grab newline character from the environment

I'm not sure what c# versions this package needs to support, does this code need to be updated to use `string.format()` rather than string interpolation?