### PR TITLE
update SemVersion.ParsedFrom to used optional biginteger

### DIFF
--- a/Semver/PublicAPI/net5.0/PublicAPI.Shipped.txt
+++ b/Semver/PublicAPI/net5.0/PublicAPI.Shipped.txt
@@ -128,7 +128,6 @@ static Semver.SemVersion.operator !=(Semver.SemVersion? left, Semver.SemVersion?
 static Semver.SemVersion.operator ==(Semver.SemVersion? left, Semver.SemVersion? right) -> bool
 static Semver.SemVersion.Parse(string! version, int maxLength = 1024) -> Semver.SemVersion!
 static Semver.SemVersion.Parse(string! version, Semver.SemVersionStyles style, int maxLength = 1024) -> Semver.SemVersion!
-static Semver.SemVersion.ParsedFrom(int major, int minor = 0, int patch = 0, string! prerelease = "", string! metadata = "", bool allowLeadingZeros = false) -> Semver.SemVersion!
 static Semver.SemVersion.PrecedenceComparer.get -> Semver.Comparers.ISemVersionComparer!
 static Semver.SemVersion.PrecedenceEquals(Semver.SemVersion? left, Semver.SemVersion? right) -> bool
 static Semver.SemVersion.SortOrderComparer.get -> Semver.Comparers.ISemVersionComparer!

--- a/Semver/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/Semver/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -30,3 +30,4 @@ Semver.SemVersion.WithParsedFrom(System.Numerics.BigInteger? major = null, Syste
 Semver.SemVersion.WithPatch(System.Numerics.BigInteger patch) -> Semver.SemVersion!
 *REMOVED*Semver.UnbrokenSemVersionRange.End.get -> Semver.SemVersion!
 Semver.UnbrokenSemVersionRange.End.get -> Semver.SemVersion?
+static Semver.SemVersion.ParsedFrom(System.Numerics.BigInteger major, System.Numerics.BigInteger? minor = null, System.Numerics.BigInteger? patch = null, string! prerelease = "", string! metadata = "", bool allowLeadingZeros = false) -> Semver.SemVersion!

--- a/Semver/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/Semver/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -128,7 +128,6 @@ static Semver.SemVersion.operator !=(Semver.SemVersion? left, Semver.SemVersion?
 static Semver.SemVersion.operator ==(Semver.SemVersion? left, Semver.SemVersion? right) -> bool
 static Semver.SemVersion.Parse(string! version, int maxLength = 1024) -> Semver.SemVersion!
 static Semver.SemVersion.Parse(string! version, Semver.SemVersionStyles style, int maxLength = 1024) -> Semver.SemVersion!
-static Semver.SemVersion.ParsedFrom(int major, int minor = 0, int patch = 0, string! prerelease = "", string! metadata = "", bool allowLeadingZeros = false) -> Semver.SemVersion!
 static Semver.SemVersion.PrecedenceComparer.get -> Semver.Comparers.ISemVersionComparer!
 static Semver.SemVersion.PrecedenceEquals(Semver.SemVersion? left, Semver.SemVersion? right) -> bool
 static Semver.SemVersion.SortOrderComparer.get -> Semver.Comparers.ISemVersionComparer!

--- a/Semver/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/Semver/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -30,3 +30,4 @@ Semver.SemVersion.WithParsedFrom(System.Numerics.BigInteger? major = null, Syste
 Semver.SemVersion.WithPatch(System.Numerics.BigInteger patch) -> Semver.SemVersion!
 *REMOVED*Semver.UnbrokenSemVersionRange.End.get -> Semver.SemVersion!
 Semver.UnbrokenSemVersionRange.End.get -> Semver.SemVersion?
+static Semver.SemVersion.ParsedFrom(System.Numerics.BigInteger major, System.Numerics.BigInteger? minor = null, System.Numerics.BigInteger? patch = null, string! prerelease = "", string! metadata = "", bool allowLeadingZeros = false) -> Semver.SemVersion!

--- a/Semver/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/Semver/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -128,7 +128,6 @@ static Semver.SemVersion.operator !=(Semver.SemVersion? left, Semver.SemVersion?
 static Semver.SemVersion.operator ==(Semver.SemVersion? left, Semver.SemVersion? right) -> bool
 static Semver.SemVersion.Parse(string! version, int maxLength = 1024) -> Semver.SemVersion!
 static Semver.SemVersion.Parse(string! version, Semver.SemVersionStyles style, int maxLength = 1024) -> Semver.SemVersion!
-static Semver.SemVersion.ParsedFrom(int major, int minor = 0, int patch = 0, string! prerelease = "", string! metadata = "", bool allowLeadingZeros = false) -> Semver.SemVersion!
 static Semver.SemVersion.PrecedenceComparer.get -> Semver.Comparers.ISemVersionComparer!
 static Semver.SemVersion.PrecedenceEquals(Semver.SemVersion? left, Semver.SemVersion? right) -> bool
 static Semver.SemVersion.SortOrderComparer.get -> Semver.Comparers.ISemVersionComparer!

--- a/Semver/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/Semver/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -30,3 +30,4 @@ Semver.SemVersion.WithParsedFrom(System.Numerics.BigInteger? major = null, Syste
 Semver.SemVersion.WithPatch(System.Numerics.BigInteger patch) -> Semver.SemVersion!
 *REMOVED*Semver.UnbrokenSemVersionRange.End.get -> Semver.SemVersion!
 Semver.UnbrokenSemVersionRange.End.get -> Semver.SemVersion?
+static Semver.SemVersion.ParsedFrom(System.Numerics.BigInteger major, System.Numerics.BigInteger? minor = null, System.Numerics.BigInteger? patch = null, string! prerelease = "", string! metadata = "", bool allowLeadingZeros = false) -> Semver.SemVersion!

--- a/Semver/SemVersion.cs
+++ b/Semver/SemVersion.cs
@@ -274,12 +274,16 @@ namespace Semver
         /// characters (i.e. characters that are not ASCII alphanumerics or hyphens).</exception>
         /// <exception cref="OverflowException">A numeric prerelease identifier value is too large
         /// for <see cref="int"/>.</exception>
-        public static SemVersion ParsedFrom(int major, int minor = 0, int patch = 0,
+        public static SemVersion ParsedFrom(BigInteger major, BigInteger? minor = null, BigInteger? patch = null,
             string prerelease = "", string metadata = "", bool allowLeadingZeros = false)
         {
-            if (major < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
-            if (minor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
-            if (patch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
+            var internalMajor = major;//for uniformity
+            var internalMinor = minor ?? 0;
+            var internalPatch = patch ?? 0;
+
+            if (internalMajor < 0) throw new ArgumentOutOfRangeException(nameof(major), InvalidMajorVersionMessage);
+            if (internalMinor < 0) throw new ArgumentOutOfRangeException(nameof(minor), InvalidMinorVersionMessage);
+            if (internalPatch < 0) throw new ArgumentOutOfRangeException(nameof(patch), InvalidPatchVersionMessage);
 
             if (prerelease is null) throw new ArgumentNullException(nameof(prerelease));
             var prereleaseIdentifiers = prerelease.Length == 0
@@ -295,7 +299,7 @@ namespace Semver
                 ? ReadOnlyList<MetadataIdentifier>.Empty
                 : metadata.SplitAndMapToReadOnlyList('.', i => new MetadataIdentifier(i, nameof(metadata)));
 
-            return new SemVersion(major, minor, patch,
+            return new SemVersion(internalMajor, internalMinor, internalPatch,
                 prerelease, prereleaseIdentifiers, metadata, metadataIdentifiers);
         }
 


### PR DESCRIPTION
Howdy and thank you for the great library!

This unsolicited PR updates the `SemVersion.ParsedFrom` method to use `BigInteger` like most of the other public methods on `SemVersion`. 

I noticed this rough edge when I updated to the 3.0.0-Beta.0 version and had some trouble moving to the new API.

Please close if this API was intentional. 

p.s.

I'm not sure if i updated the shipped/unshipped files correctly, this is the first time I've encountered them