### PR TITLE
Mark assembly as CLS compliant

### DIFF
--- a/Semver/Properties/AssemblyInfo.cs
+++ b/Semver/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+[assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 [assembly: Guid("e208ca67-5b59-45d9-a29a-7f30137d3beb")]
 


### PR DESCRIPTION
Adds the `CLSCompliant(true)` attribute on assembly level.

This allows the `SemVersion` class to be used in other CLS compliant libraries as e.g. a public class member.

More information:
https://learn.microsoft.com/en-us/dotnet/standard/language-independence

The library itself already is fully CLS compliant, just the attribute was missing.