### PR TITLE
Replace IndexRange with Microsoft.Bcl.Memory

### DIFF
--- a/Semver.Benchmarks/Semver.Benchmarks.csproj
+++ b/Semver.Benchmarks/Semver.Benchmarks.csproj
@@ -18,7 +18,7 @@
       <PackageReference Include="BenchmarkDotNet">
         <Version>0.14.0</Version>
       </PackageReference>
-      <PackageReference Include="IndexRange" Version="1.0.3" />
+      <PackageReference Include="IndexRange" Version="1.1.0" />
       <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
       <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.1"
                         Condition="'$(TargetFramework)' == 'net481'" />

--- a/Semver.Test/Semver.Test.csproj
+++ b/Semver.Test/Semver.Test.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IndexRange" Version="1.0.3" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Semver/Semver.csproj
+++ b/Semver/Semver.csproj
@@ -44,7 +44,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IndexRange" Version="1.0.3" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.7" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="JetBrains.dotCover.MSBuild" Version="1.0.5-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
I'm the creator of the [IndexRange package](https://www.nuget.org/packages/IndexRange). The `Index` and `Range` types now exist in an official Microsoft package and don't need to be supplied by a third-party package.

Still using IndexRange in Semver.Benchmarks due to its dependency on a previous version of the Semver package.